### PR TITLE
update relative imports for py3

### DIFF
--- a/grainhill/block_hill.py
+++ b/grainhill/block_hill.py
@@ -9,7 +9,7 @@ Created on Sat Jun 24 10:54:53 2017
 """
 
 from grainhill import GrainHill
-from lattice_grain import (lattice_grain_node_states,
+from .lattice_grain import (lattice_grain_node_states,
                            lattice_grain_transition_list)
 from landlab.ca.boundaries.hex_lattice_tectonicizer import LatticeUplifter
 from landlab.ca.celllab_cts import Transition

--- a/grainhill/grain_facet.py
+++ b/grainhill/grain_facet.py
@@ -6,8 +6,8 @@ Hillslope model with block uplift.
 _DEBUG = False
 
 import sys
-from cts_model import CTSModel
-from lattice_grain import (lattice_grain_node_states,
+from .cts_model import CTSModel
+from .lattice_grain import (lattice_grain_node_states,
                            lattice_grain_transition_list)
 import time
 from numpy import zeros, count_nonzero, where, amax, logical_and

--- a/grainhill/grain_facet_model.py
+++ b/grainhill/grain_facet_model.py
@@ -252,7 +252,7 @@ class GrainFacetSimulator(CTSModel):
                                         rock_state=8)
                 for i in range(self.grid.number_of_links):
                     if self.grid.status_at_link[i] == 4 and self.ca.next_trn_id[i] != -1:
-                        print i
+                        print(i)
                 next_uplift += self.uplift_interval
 
             # Handle baselevel rise

--- a/grainhill/grain_hill.py
+++ b/grainhill/grain_hill.py
@@ -6,8 +6,8 @@ Hillslope model with block uplift.
 _DEBUG = False
 
 import sys
-from cts_model import CTSModel
-from lattice_grain import (lattice_grain_node_states,
+from .cts_model import CTSModel
+from .lattice_grain import (lattice_grain_node_states,
                            lattice_grain_transition_list)
 import time
 from numpy import zeros, count_nonzero, where, amax, logical_and


### PR DESCRIPTION
Makes imports work properly under Python 3.x.